### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EasingBase  KEYWORD1
-BackEase  KEYWORD1
-BounceEase KEYWORD1
-CircularEase KEYWORD1
-CubicEase KEYWORD1
-ElasticEase KEYWORD1
-ExponentialEase KEYWORD1
-LinearEase KEYWORD1
-QuadraticEase KEYWORD1
-QuarticEase KEYWORD1
-QuinticEase KEYWORD1
-SineEase  KEYWORD1
+EasingBase	KEYWORD1
+BackEase	KEYWORD1
+BounceEase	KEYWORD1
+CircularEase	KEYWORD1
+CubicEase	KEYWORD1
+ElasticEase	KEYWORD1
+ExponentialEase	KEYWORD1
+LinearEase	KEYWORD1
+QuadraticEase	KEYWORD1
+QuarticEase	KEYWORD1
+QuinticEase	KEYWORD1
+SineEase	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords